### PR TITLE
Update CORS configuration to latest config options

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -108,7 +108,7 @@ grails:
     cors:
         enabled: true
         # The following are the defaults
-        allowedOrigins: [ '*' ]
+        allowedOriginPatterns: [ '*' ]
         allowedMethods: [ 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'HEAD' ]
         allowedHeaders: [ 'origin', 'content-type', 'accept', 'authorization', 'pragma', 'cache-control' ]
         #exposedHeaders: null


### PR DESCRIPTION
I think the template has since been updated.  Allows the UI to work against the plugin when run alone in bootRun mode