### PR TITLE
gh-15 Add endpoint to return root data model

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ also run the backend on its own from [mdm-application-build](https://github.com/
 
 An API property `explorer.config.root_data_model_path` defines the location of the source Data Model i.e. the Data Model which the user browses, and from
 which they select Data Elements. For example, if the source Data Model is called 'Source' and is located in a folder 'F', this property
-must have a value of 'fo:F|dm:Source'.
+must have a value of 'fo:F|dm:Source'. You can retrieve this root data model using the endpoint `GET /explorer/rootDataModel`.
 
 The following API properties are also required:
 - `explorer.config.root_request_folder` The name of a folder in the catalogue where all user requests will be stored. 

--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerInterceptor.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerInterceptor.groovy
@@ -24,7 +24,7 @@ class ExplorerInterceptor implements MdmInterceptor {
     boolean before() {
 
         // Ability to create a user folder is available to any authenticated user
-        if (['userFolder', 'templateFolder'].contains(actionName)) {
+        if (['userFolder', 'templateFolder', 'rootDataModel'].contains(actionName)) {
             if (currentUserSecurityPolicyManager.isAuthenticated()) {
                 return true
             }

--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/UrlMappings.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/UrlMappings.groovy
@@ -27,6 +27,7 @@ class UrlMappings {
             group '/explorer', {
                 post "/userFolder"(controller: 'explorer', action: 'userFolder')
                 get "/templateFolder"(controller: 'explorer', action: 'templateFolder')
+                get "/rootDataModel"(controller: 'explorer', action: 'rootDataModel')
             }
         }
     }


### PR DESCRIPTION
- Add various checks to ensure root data mode is accessible
- Integration tests included

This will be useful for the `mdm-explorer` to simplify getting the root data model for exploration.

Resolves #15 