### PR TITLE
gh18 New theming API properties

### DIFF
--- a/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/BootStrap.groovy
+++ b/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/BootStrap.groovy
@@ -119,7 +119,6 @@ class BootStrap implements SecurityDefinition {
                 new Tuple('explorer.theme.material.typography.subheadingtwo','16px, 28px, 400'),
                 new Tuple('explorer.theme.material.typography.subheadingone','15px, 24px, 400'),
                 new Tuple('explorer.theme.material.typography.button','14px, 14px, 400'),
-                new Tuple('explorer.theme.material.typography.input','inherit, , 400'),
                 new Tuple('explorer.theme.regularcolors.hyperlink','#003752'),
                 new Tuple('explorer.theme.regularcolors.requestcount','#ffe603'),
                 new Tuple('explorer.theme.contrastcolors.page','#fff'),


### PR DESCRIPTION
Added the new API theming properties as details on the ticket - Agreed outcome for note (2) was to exclude explorer.theme.material.typography.input from the properties. Note (3) will be handled as a new issue in the mdm-ui repo.

closes #18 