### PR TITLE
gh-38: Create a Data Model level Profile to identify core data specif…

### DIFF
--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerController.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerController.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerInterceptor.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerInterceptor.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/UrlMappings.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/UrlMappings.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/ResearchController.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/ResearchController.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/ResearchInterceptor.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/ResearchInterceptor.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/Application.groovy
+++ b/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/Application.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/BootStrap.groovy
+++ b/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/BootStrap.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderCoreTableProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderCoreTableProfileProviderService.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020-2023 University of Oxford and NHS England
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder
+
+import uk.ac.ox.softeng.maurodatamapper.core.model.facet.MultiFacetAware
+import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
+import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModelService
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataClass
+import uk.ac.ox.softeng.maurodatamapper.profile.domain.ProfileField
+import uk.ac.ox.softeng.maurodatamapper.profile.object.JsonProfile
+import uk.ac.ox.softeng.maurodatamapper.profile.provider.EmptyJsonProfileFactory
+import uk.ac.ox.softeng.maurodatamapper.profile.provider.JsonProfileProviderService
+
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+
+@Slf4j
+class QueryBuilderCoreTableProfileProviderService extends JsonProfileProviderService {
+
+    private UUID dataModelId
+
+    @Autowired
+    DataModelService dataModelService
+
+
+    @Override
+    String getMetadataNamespace() {
+        'uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder'
+    }
+
+    @Override
+    String getDisplayName() {
+        'Mauro Data Explorer - Query Builder Core Table'
+    }
+
+    @Override
+    String getVersion() {
+        '1.0.0'
+    }
+
+    @Override
+    String getJsonResourceFile() {
+        return 'queryBuilderCoreTableProfile.json'
+    }
+
+    @Override
+    List<String> profileApplicableForDomains() {
+        return ['DataModel']
+    }
+
+    @Override
+    JsonProfile createProfileFromEntity(MultiFacetAware entity) {
+        dataModelId = entity.id
+        super.createProfileFromEntity(entity)
+    }
+
+    @Override
+    JsonProfile getNewProfile() {
+        JsonProfile emptyProfile = EmptyJsonProfileFactory.instance.getEmptyProfile(this)
+        emptyProfile.sections[0].customFieldsValidation {fields, errors ->
+                String errorLabel = 'Query Builder core table'
+                String errorField = 'queryBuilderCoreTable'
+                String coreTable = fields.find {it.metadataPropertyName == 'queryBuilderCoreTable'}.currentValue
+                String[] stringParts = coreTable.split('\\.')
+                if (stringParts.size() != 2) return errors.rejectValue("fields[0].currentValue", 'schema.table.format.must.be.valid',
+                                                                       new Object[]{'currentValue', ProfileField.simpleName, null, errorLabel, errorField},
+                                                                       'Format needs to be [Schema].[Table] e.g: people.patient')
+                String schemaName = stringParts[0]
+                String tableName = stringParts[1]
+
+                DataModel dataModel = dataModelService.get(dataModelId)
+                if (dataModel) {
+                    DataClass dataSchema = dataModel.dataClasses.find({it.label == schemaName})
+                    if (dataSchema) {
+                        DataClass dataTable = dataSchema.dataClasses.find({it.label == tableName})
+                        if (!dataTable) {
+                            errors.rejectValue("fields[0].currentValue", 'table.must.belong.to.schema',
+                                               new Object[]{'currentValue', 'ProfileField.simpleName', null, errorLabel, errorField},
+                                               "Table \"${tableName}\" cannot be found in schema \"${schemaName}\"")
+                        }
+                    } else {
+                        errors.rejectValue("fields[0].currentValue", 'schema.must.belong.to.datamodel',
+                                           new Object[]{'currentValue', 'ProfileField.simpleName', null, errorLabel, errorField},
+                                           "Schema \"${schemaName}\" cannot be found")
+                    }
+                }
+                else {
+                    // We should never reach this point
+                    errors.rejectValue("fields[0].currentValue", 'datamodel.not.found',
+                                       new Object[]{'currentValue', 'ProfileField.simpleName', null, errorLabel, errorField},
+                                       "DataModel \"${dataModelId}\" cannot be found")
+                }
+
+                return
+            }
+
+        emptyProfile
+    }
+}

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderCoreTableProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderCoreTableProfileProviderService.groovy
@@ -1,19 +1,19 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 package uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder
 

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderCoreTableProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderCoreTableProfileProviderService.groovy
@@ -101,9 +101,7 @@ class QueryBuilderCoreTableProfileProviderService extends JsonProfileProviderSer
                 }
                 else {
                     // We should never reach this point
-                    errors.rejectValue("fields[0].currentValue", 'datamodel.not.found',
-                                       new Object[]{'currentValue', 'ProfileField.simpleName', null, errorLabel, errorField},
-                                       "DataModel \"${dataModelId}\" cannot be found")
+                    throw new Error("DataModel \"${dataModelId}\" cannot be found")
                 }
 
                 return

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderPrimitiveTypeProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderPrimitiveTypeProfileProviderService.groovy
@@ -1,19 +1,19 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 package uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder
 

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/ResearchDataElementProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/ResearchDataElementProfileProviderService.groovy
@@ -1,19 +1,19 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 package uk.ac.ox.softeng.maurodatamapper.plugins.explorer.research
 

--- a/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/gorm/mapping/MdmPluginExplorerSchemaMappingContext.groovy
+++ b/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/gorm/mapping/MdmPluginExplorerSchemaMappingContext.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/rest/transport/Contact.groovy
+++ b/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/rest/transport/Contact.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/rest/transport/search/searchparamfilter/ResearchProfileFilter.groovy
+++ b/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/rest/transport/search/searchparamfilter/ResearchProfileFilter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerFunctionalSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerFunctionalSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package uk.ac.ox.softeng.maurodatamapper.plugins.explorer
 
 import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyService

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderFunctionalSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderFunctionalSpec.groovy
@@ -62,6 +62,8 @@ class QueryBuilderFunctionalSpec extends BaseFunctionalSpec implements SecurityD
     QueryBuilderCoreTableProfileProviderService queryBuilderCoreTableProfileProviderService
     GroupBasedSecurityPolicyManagerService groupBasedSecurityPolicyManagerService
 
+    // Setup a DataModel for the tests. This only needs to be run once for all tests since
+    // the tests do not change the DataModel.
     @RunOnce
     @Transactional
     def setup() {
@@ -134,7 +136,7 @@ class QueryBuilderFunctionalSpec extends BaseFunctionalSpec implements SecurityD
     }
 
     void 'S01: query builder profile, test validity of core table string'(String coreTable, String[] expectedErrors) {
-        when:
+        given: 'The user has a complete query builder core table profile with the given value for the coreTable field'
         QueryBuilderCoreTableProfileProviderService pps = queryBuilderCoreTableProfileProviderService
         String endpointPrefix = "dataModels/${dataModelId}"
         Map profileMap =
@@ -152,12 +154,13 @@ class QueryBuilderFunctionalSpec extends BaseFunctionalSpec implements SecurityD
                 label: "${dataModelLabel}",
             ]
 
+        when: 'The profile is validated'
         // We need to run the GET first to setup the dataModelId for the validation
         // This is the way profiles are called from the Mauro UI so the validation code should be safe
         GET("${endpointPrefix}/profile/${pps.namespace}/${pps.name}/${pps.version}")
         POST("${endpointPrefix}/profile/${pps.namespace}/${pps.name}/validate", profileMap)
 
-        then:
+        then: 'The expected validation results are produced (expectedErrors)'
         if (expectedErrors.size() == 0) {
             verifyResponse(OK, response)
             Assert.assertEquals(coreTable, responseBody().sections.fields[0].currentValue[0])

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderFunctionalSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderFunctionalSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder
 
 import uk.ac.ox.softeng.maurodatamapper.core.authority.Authority

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderFunctionalSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/querybuilder/QueryBuilderFunctionalSpec.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020-2023 University of Oxford and NHS England
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder
+
+import uk.ac.ox.softeng.maurodatamapper.core.authority.Authority
+import uk.ac.ox.softeng.maurodatamapper.core.container.Folder
+import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
+import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModelType
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataClass
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataElement
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.PrimitiveType
+import uk.ac.ox.softeng.maurodatamapper.security.basic.UnloggedUser
+import uk.ac.ox.softeng.maurodatamapper.security.policy.GroupBasedSecurityPolicyManagerService
+import uk.ac.ox.softeng.maurodatamapper.security.utils.SecurityDefinition
+import uk.ac.ox.softeng.maurodatamapper.test.functional.BaseFunctionalSpec
+
+import grails.gorm.transactions.Transactional
+import grails.testing.mixin.integration.Integration
+import grails.testing.spock.RunOnce
+import groovy.util.logging.Slf4j
+import org.junit.Assert
+import org.junit.jupiter.api.Tag
+import spock.lang.Shared
+
+import static uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddress.FUNCTIONAL_TEST
+import static uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddress.getDEVELOPMENT
+
+import static io.micronaut.http.HttpStatus.OK
+import static io.micronaut.http.HttpStatus.UNPROCESSABLE_ENTITY
+
+/**
+ * @since 12/04/2022
+ */
+@Tag('non-parallel')
+@Integration
+@Slf4j
+class QueryBuilderFunctionalSpec extends BaseFunctionalSpec implements SecurityDefinition {
+
+    @Shared
+    Folder folder
+
+    @Shared
+    UUID dataModelId
+    String dataModelLabel = 'Query Builder Functional Test Data Model'
+
+    QueryBuilderCoreTableProfileProviderService queryBuilderCoreTableProfileProviderService
+    GroupBasedSecurityPolicyManagerService groupBasedSecurityPolicyManagerService
+
+    @RunOnce
+    @Transactional
+    def setup() {
+        log.debug('Check and setup test data')
+        folder = new Folder(label: 'Search Functional Test Folder', createdBy: FUNCTIONAL_TEST).save()
+
+        DataModel dataModel = new DataModel(createdBy: FUNCTIONAL_TEST,
+                                            label: dataModelLabel,
+                                            folder: folder,
+                                            type: DataModelType.DATA_ASSET,
+                                            authority: Authority.findByDefaultAuthority(true),
+                                            readableByEveryone: true)
+        checkAndSave(dataModel)
+        dataModelId = dataModel.id
+        PrimitiveType stringPrimitive = new PrimitiveType(createdBy: DEVELOPMENT, label: 'string')
+        dataModel.addToDataTypes(stringPrimitive)
+        checkAndSave(dataModel)
+
+        DataClass peopleSchema = new DataClass(label: 'people', createdBy: FUNCTIONAL_TEST)
+        dataModel.addToDataClasses(peopleSchema)
+
+        DataClass medicalSchema = new DataClass(label: 'medical', createdBy: FUNCTIONAL_TEST)
+        dataModel.addToDataClasses(medicalSchema)
+        checkAndSave(dataModel)
+
+        DataClass patient = new DataClass(label: 'patient', createdBy: FUNCTIONAL_TEST)
+        patient.addToDataElements(
+            new DataElement(label: 'name', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        patient.addToDataElements(
+            new DataElement(label: 'nhs_number', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        patient.addToDataElements(
+            new DataElement(label: 'date_of_birth', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        peopleSchema.addToDataClasses(patient)
+        checkAndSave(dataModel)
+
+        DataClass labTest = new DataClass(label: 'lab_test', createdBy: FUNCTIONAL_TEST)
+        labTest.addToDataElements(
+            new DataElement(label: 'test_result', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        labTest.addToDataElements(
+            new DataElement(label: 'test_code', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        labTest.addToDataElements(
+            new DataElement(label: 'test_date', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        medicalSchema.addToDataClasses(labTest)
+
+        DataClass diagnosis = new DataClass(label: 'diagnosis', createdBy: FUNCTIONAL_TEST)
+        diagnosis.addToDataElements(
+            new DataElement(label: 'diagnosis_result', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        diagnosis.addToDataElements(
+            new DataElement(label: 'diagnosis_code', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        diagnosis.addToDataElements(
+            new DataElement(label: 'diagnosis_date', createdBy: FUNCTIONAL_TEST, dataType: stringPrimitive))
+        medicalSchema.addToDataClasses(diagnosis)
+
+        checkAndSave(dataModel)
+        sessionFactory.currentSession.flush()
+
+        groupBasedSecurityPolicyManagerService.reloadUserSecurityPolicyManager(UnloggedUser.UNLOGGED_EMAIL_ADDRESS)
+    }
+
+    @Transactional
+    def cleanupSpec() {
+        log.debug('CleanupSpec SearchFunctionalSpec')
+        DataModel.get(dataModelId).delete()
+        folder.delete()
+    }
+
+    @Override
+    String getResourcePath() {
+        ''
+    }
+
+    void 'S01: query builder profile, test validity of core table string'(String coreTable, String[] expectedErrors) {
+        when:
+        QueryBuilderCoreTableProfileProviderService pps = queryBuilderCoreTableProfileProviderService
+        String endpointPrefix = "dataModels/${dataModelId}"
+        Map profileMap =
+            [
+                sections: [
+                    [
+                        name  : 'Query Builder Core Table Profile',
+                        fields: [
+                            [metadataPropertyName: 'queryBuilderCoreTable', currentValue: coreTable],
+                            [metadataPropertyName: 'multiplicity', currentValue: 1]
+                        ]
+                    ]
+                ],
+                id: "${dataModelId}",
+                label: "${dataModelLabel}",
+            ]
+
+        // We need to run the GET first to setup the dataModelId for the validation
+        // This is the way profiles are called from the Mauro UI so the validation code should be safe
+        GET("${endpointPrefix}/profile/${pps.namespace}/${pps.name}/${pps.version}")
+        POST("${endpointPrefix}/profile/${pps.namespace}/${pps.name}/validate", profileMap)
+
+        then:
+        if (expectedErrors.size() == 0) {
+            verifyResponse(OK, response)
+            Assert.assertEquals(coreTable, responseBody().sections.fields[0].currentValue[0])
+        } else {
+            verifyResponse(UNPROCESSABLE_ENTITY, response)
+            Assert.assertEquals(expectedErrors.size(), responseBody().total)
+            expectedErrors.each {String errorMessage ->
+                Assert.assertTrue(responseBody().errors.any{it.message == errorMessage})
+            }
+        }
+
+        where:
+        coreTable           | expectedErrors
+        "people.patient"    | []
+        ""                  | ["This field cannot be empty","Format needs to be [Schema].[Table] e.g: people.patient"]
+        "invalidformat"     | ["Format needs to be [Schema].[Table] e.g: people.patient"]
+        "badschema.patient" | ["Schema \"badschema\" cannot be found"]
+        "people.badtable"   | ["Table \"badtable\" cannot be found in schema \"people\""]
+    }
+
+}

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/ResearchFunctionalSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/ResearchFunctionalSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package uk.ac.ox.softeng.maurodatamapper.plugins.explorer.research
 
 import uk.ac.ox.softeng.maurodatamapper.core.container.Folder

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/SearchFunctionalSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/research/SearchFunctionalSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package uk.ac.ox.softeng.maurodatamapper.plugins.explorer.research
 
 import uk.ac.ox.softeng.maurodatamapper.core.authority.Authority

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/MdmPluginExplorerGrailsPlugin.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/MdmPluginExplorerGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 University of Oxford and NHS England
+ * Copyright 2020-2024 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/queryBuilderCoreTableProfile.json
+++ b/src/main/resources/queryBuilderCoreTableProfile.json
@@ -1,0 +1,17 @@
+[
+  {
+    "sectionName": "Query Builder Core Table Profile",
+    "sectionDescription": "This profile defines the table that sits in the middle of the star schema. The query builder cohort query will use this table as it's main table.",
+    "fields": [
+      {
+        "fieldName": "Query Builder core table",
+        "metadataPropertyName": "queryBuilderCoreTable",
+        "description": "The name of the core table that is in the middle of the star schema. This should be written in the format schema.table, e.g patients.patient",
+        "minMultiplicity": 1,
+        "maxMultiplicity": 1,
+        "dataType": "string",
+        "editableAfterFinalisation": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
…ication table

To build this you will need to build the mdm-plugin-explorer and then publish it to maven local. Then in the mdm-core make sure that the local copy is reference in build.gradle.
```
grails {
    plugins {
        ...
        runtimeOnly 'uk.ac.ox.softeng.maurodatamapper.plugins:mdm-plugin-explorer:1.0.0-SNAPSHOT'
    }
}
```

To test this you will need to login to the standard Mauro UI. Then select a data model and add the new "Mauro Data Explorer - Query Builder Core Table" to that profile. The validate button will tell you if the data you have entered is correct.
![image](https://github.com/MauroDataMapper-Plugins/mdm-plugin-explorer/assets/110250803/4371e8ae-9bd9-4269-9779-66fb56539e70)

This new profile has been created to identify the core of a star schema. The MDE expects the data model to be a star schema and the query builder will be using the information from this new profile to identify which table is the core.

Here is a simple data model that can be imported into your copy of Mauro to test this work. The core table is the Patient table.
[patientdb_20240305T143738.json](https://github.com/MauroDataMapper-Plugins/mdm-plugin-explorer/files/14496810/patientdb_20240305T143738.json)


