### PR TITLE
gh-49 - allow retrieval of necessary coretable data elements ids

### DIFF
--- a/grails-app/DTOs/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/SchemaTablePair.groovy
+++ b/grails-app/DTOs/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/SchemaTablePair.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020-2024 University of Oxford and NHS England
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.plugins.explorer
+
+class SchemaTablePair {
+    private String schema;
+    private String table;
+
+    SchemaTablePair(String schema, String table ) {
+        this.schema = schema
+        this.table = table
+    }
+
+    String getSchema() {
+        schema
+    }
+
+    String getTable() {
+        table
+    }
+}

--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerInterceptor.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/ExplorerInterceptor.groovy
@@ -29,7 +29,7 @@ class ExplorerInterceptor implements MdmInterceptor {
 
         // Authenticated user access only
         if (['userFolder', 'templateFolder', 'rootDataModel',
-             'sharedDataSpecifications', 'getLatestModelDataSpecifications'].contains(actionName)) {
+             'sharedDataSpecifications', 'getLatestModelDataSpecifications', 'getRequiredCoreTableDataElementIds'].contains(actionName)) {
             if (currentUserSecurityPolicyManager.isAuthenticated()) {
                 return true
             }

--- a/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/UrlMappings.groovy
+++ b/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/plugins/explorer/UrlMappings.groovy
@@ -31,6 +31,7 @@ class UrlMappings {
                 get "/rootDataModel"(controller: 'explorer', action: 'rootDataModel')
                 get "/sharedDataSpecifications"(controller: 'explorer', action: 'sharedDataSpecifications')
                 get "/getLatestModelDataSpecifications"(controller: 'explorer', action: 'getLatestModelDataSpecifications')
+                post "/getRequiredCoreTableDataElementIds"(controller: 'explorer', action: 'getRequiredCoreTableDataElementIds')
             }
         }
     }


### PR DESCRIPTION
Given a set of data element ids, add the primary key data element of the core table and any data elements corresponding to foreign keys to the core table that are peers of the incoming data elements.

For testing: 
- Ensure when creating a new/copying to a data spec results in both the primary key and foreign key being added automatically. 
- Ensure no duplicates are created. 

Known issue: 
- Upon successful completion of copy/create, the dialog that tells you what has been added does not include the auto added pk/fk elements. 

Needs to be tested alongside maurodatamapper/mdm-explorer#372

closes #49 