### PR TITLE
Update dita-dsl version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation "org.freemarker:freemarker:2.3.32"
 
     // PDF Exporter
-    implementation group: 'uk.ac.ox.softeng.maurodatamapper', name: 'dita-dsl', version: '1.0.0-SNAPSHOT'
+    implementation group: 'org.maurodata', name: 'dita-dsl', version: '1.0.0-SNAPSHOT'
 
     testImplementation 'org.apache.pdfbox:pdfbox:2.0.27'
 

--- a/src/integration-test/resources/exporter/cohort and data queries/ditaDataSpecification_mainMap.xml
+++ b/src/integration-test/resources/exporter/cohort and data queries/ditaDataSpecification_mainMap.xml
@@ -1,8 +1,4 @@
 <map id='sample-data_onboarded'>
   <title>sample-data_onboarded</title>
-  <mapref href='links/internalImageLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/internalTopicLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/internalMapLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/externalLinks.ditamap' processing-role='resource-only' />
   <topicref keyref='datamodel' toc='yes' />
 </map>

--- a/src/integration-test/resources/exporter/cohort query only (int only)/ditaDataSpecification_mainMap.xml
+++ b/src/integration-test/resources/exporter/cohort query only (int only)/ditaDataSpecification_mainMap.xml
@@ -1,8 +1,4 @@
 <map id='sample-data_onboarded'>
   <title>sample-data_onboarded</title>
-  <mapref href='links/internalImageLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/internalTopicLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/internalMapLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/externalLinks.ditamap' processing-role='resource-only' />
   <topicref keyref='datamodel' toc='yes' />
 </map>

--- a/src/integration-test/resources/exporter/data query only (int only)/ditaDataSpecification_mainMap.xml
+++ b/src/integration-test/resources/exporter/data query only (int only)/ditaDataSpecification_mainMap.xml
@@ -1,8 +1,4 @@
 <map id='sample-data_onboarded'>
   <title>sample-data_onboarded</title>
-  <mapref href='links/internalImageLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/internalTopicLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/internalMapLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/externalLinks.ditamap' processing-role='resource-only' />
   <topicref keyref='datamodel' toc='yes' />
 </map>

--- a/src/integration-test/resources/exporter/no queries/ditaDataSpecification_mainMap.xml
+++ b/src/integration-test/resources/exporter/no queries/ditaDataSpecification_mainMap.xml
@@ -1,8 +1,4 @@
 <map id='sample-data_onboarded'>
   <title>sample-data_onboarded</title>
-  <mapref href='links/internalImageLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/internalTopicLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/internalMapLinks.ditamap' processing-role='resource-only' />
-  <mapref href='links/externalLinks.ditamap' processing-role='resource-only' />
   <topicref keyref='datamodel' toc='yes' />
 </map>


### PR DESCRIPTION
Update to use the new `org.maurodata` group name for dita-dsl

Depends on https://github.com/MauroDataMapper/dita-groovy-dsl/pull/11